### PR TITLE
ci: add build and test matrix for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .tool-versions
+          cache: pip
+
+      - name: Install Conan
+        run: pip install -r requirements.txt
+
+      - name: Detect Conan profile
+        run: conan profile detect --force
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', 'requirements.txt') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Test
+        run: ctest --test-dir build --build-config Release --output-on-failure


### PR DESCRIPTION
## Summary

- Add `.github/workflows/build.yml` with multi-platform build matrix
- Platforms: Linux (ubuntu-latest), macOS (macos-latest), Windows (windows-latest)
- Steps: setup Python from `.tool-versions`, install Conan from `requirements.txt`,
  CMake configure, build, and test via ctest
- Caching: pip cache via `setup-python`, Conan packages via `actions/cache`

## Test plan

- [ ] Build succeeds on Ubuntu
- [ ] Build succeeds on macOS
- [ ] Build succeeds on Windows
- [ ] All 13 unit tests pass on all platforms

Closes #16