### PR TITLE
ci: add label-driven verify and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,102 @@
+name: Publish RC
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+
+jobs:
+  check-version:
+    name: Check version
+    if: contains(github.event.pull_request.labels.*.name, 'publish')
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      rc_version: ${{ steps.version.outputs.rc_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -oP 'project\(\s*numops\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          RC_VERSION="${VERSION}-dev-${SHORT_SHA}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rc_version=${RC_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Release version: ${VERSION}"
+          echo "RC version: ${RC_VERSION}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .tool-versions
+          cache: pip
+
+      - name: Install Conan
+        run: pip install -r requirements.txt
+
+      - name: Detect Conan profile
+        run: conan profile detect --force
+
+      - name: Configure conan-stable remote
+        run: |
+          conan remote add conan-stable "${{ secrets.JFROG_URL }}/conan-stable"
+          conan remote login conan-stable "${{ secrets.JFROG_USER }}" -p "${{ secrets.JFROG_TOKEN }}"
+
+      - name: Check version does not exist in conan-stable
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          if conan search "numops/${VERSION}" -r conan-stable 2>&1 | grep -q "Found"; then
+            echo "::error::Version ${VERSION} already exists in conan-stable. Bump the version."
+            exit 1
+          fi
+          echo "Version ${VERSION} is available."
+
+  publish-rc:
+    name: Publish RC (${{ matrix.os }})
+    needs: check-version
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .tool-versions
+          cache: pip
+
+      - name: Install Conan
+        run: pip install -r requirements.txt
+
+      - name: Detect Conan profile
+        run: conan profile detect --force
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', 'requirements.txt') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Configure conan-rc remote
+        run: |
+          conan remote add conan-rc "${{ secrets.JFROG_URL }}/conan-rc"
+          conan remote login conan-rc "${{ secrets.JFROG_USER }}" -p "${{ secrets.JFROG_TOKEN }}"
+
+      - name: Build and upload RC package
+        run: |
+          conan create . --version="${{ needs.check-version.outputs.rc_version }}"
+          conan upload "numops/${{ needs.check-version.outputs.rc_version }}" -r conan-rc --confirm

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,47 @@
+name: Verify
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+
+jobs:
+  integration-test:
+    name: Integration (${{ matrix.os }})
+    if: contains(github.event.pull_request.labels.*.name, 'verify')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .tool-versions
+          cache: pip
+
+      - name: Install Conan
+        run: pip install -r requirements.txt
+
+      - name: Detect Conan profile
+        run: conan profile detect --force
+
+      - name: Cache Conan packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.conan2
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', 'requirements.txt') }}
+          restore-keys: |
+            conan-${{ runner.os }}-
+
+      - name: Run integration test
+        run: conan create .


### PR DESCRIPTION
## Summary

- Add `.github/workflows/verify.yml` — triggered by `verify` label on PRs
  - Runs `conan create .` (integration test) on Linux, macOS, Windows
- Add `.github/workflows/publish.yml` — triggered by `publish` label on PRs
  - Extracts version from `CMakeLists.txt`
  - Checks version doesn't already exist in `conan-stable`
  - Builds RC packages (`numops/X.Y.Z-dev-<sha>`) on all platforms
  - Uploads RC packages to `conan-rc` remote
- Create `verify` and `publish` GitHub labels

## Prerequisites

- JFrog Artifactory secrets configured: `JFROG_URL`, `JFROG_USER`, `JFROG_TOKEN`
- Two Conan repositories: `conan-rc` and `conan-stable`

## Test plan

- [ ] Lint and build checks pass
- [ ] Adding `verify` label triggers integration tests
- [ ] Adding `publish` label builds and uploads RC packages
- [ ] `publish` workflow fails if version exists in `conan-stable`

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated release candidate publishing workflow with version verification and multi-platform support.
  * Added automated integration testing workflow triggered on pull request labels, running across Ubuntu, macOS, and Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->