### PR TITLE
ci: add release-on-merge workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Check version does not exist in conan-stable
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if conan search "numops/${VERSION}" -r conan-stable 2>&1 | grep -q "Found"; then
+          EXISTS=$(conan list "numops/${VERSION}" -r conan-stable --format=json \
+            | jq --arg ref "numops/${VERSION}" '.["conan-stable"] | has($ref)')
+          if [ "${EXISTS}" = "true" ]; then
             echo "::error::Version ${VERSION} already exists in conan-stable. Bump the version."
             exit 1
           fi
@@ -82,14 +84,6 @@ jobs:
 
       - name: Detect Conan profile
         run: conan profile detect --force
-
-      - name: Cache Conan packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', 'requirements.txt') }}
-          restore-keys: |
-            conan-${{ runner.os }}-
 
       - name: Configure conan-rc remote
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ permissions:
 jobs:
   release:
     name: Release
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'publish')
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'publish')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -69,14 +71,6 @@ jobs:
       - name: Detect Conan profile
         run: conan profile detect --force
 
-      - name: Cache Conan packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.conan2
-          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', 'requirements.txt') }}
-          restore-keys: |
-            conan-${{ runner.os }}-
-
       - name: Configure conan-stable remote
         run: |
           conan remote add conan-stable "${{ secrets.JFROG_URL }}/conan-stable"
@@ -86,3 +80,43 @@ jobs:
         run: |
           conan create . --version="${{ needs.release.outputs.version }}"
           conan upload "numops/${{ needs.release.outputs.version }}" -r conan-stable --confirm
+
+      - name: Package artifacts
+        shell: bash
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          PKG_PATH=$(conan cache path "numops/${VERSION}:*" 2>/dev/null || true)
+          mkdir -p dist
+          if [ -n "${PKG_PATH}" ] && [ -d "${PKG_PATH}" ]; then
+            tar czf "dist/numops-${VERSION}-${{ matrix.os }}.tar.gz" -C "${PKG_PATH}" .
+          else
+            echo "Package path not found, creating metadata-only artifact"
+            echo "numops/${VERSION} published to conan-stable" > "dist/numops-${VERSION}-${{ matrix.os }}.txt"
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: numops-${{ matrix.os }}
+          path: dist/*
+
+  attach-artifacts:
+    name: Attach release artifacts
+    needs:
+      - release
+      - publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Upload to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "v${{ needs.release.outputs.version }}" \
+            artifacts/* --clobber \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -43,5 +43,14 @@ jobs:
           restore-keys: |
             conan-${{ runner.os }}-
 
+      - name: Compute RC version
+        id: version
+        shell: bash
+        run: |
+          VERSION=$(grep -oE 'project\(\s*numops\s+VERSION\s+[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          echo "rc_version=${VERSION}-dev-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Run integration test
-        run: conan create .
+        run: conan create . --version="${{ steps.version.outputs.rc_version }}"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered when a `publish`-labeled PR is merged to `main`
- **Release job** (ubuntu-latest):
  - Extracts version from `CMakeLists.txt`
  - Creates git tag `vX.Y.Z`
  - Creates GitHub Release with auto-generated notes
- **Publish job** (Linux, macOS, Windows):
  - Builds final Conan packages as `numops/X.Y.Z`
  - Uploads to `conan-stable` remote

## Test plan

- [ ] Lint and build checks pass
- [ ] Workflow can be tested by merging this PR with `publish` label
  (this will create tag `v1.0.0` and publish `numops/1.0.0` to conan-stable)

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end automated release and packaging: on merged PRs with a publish label, releases are tagged, GitHub Releases created, and OS-specific packages are built and attached.
  * Verify workflow now publishes RC-versioned packages for integration testing.

* **Chores**
  * Improved publish checks to detect existing versions via structured lookup and removed prior package cache step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->