### PR TITLE
fix: export actual Conan package contents as release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,14 +85,12 @@ jobs:
         shell: bash
         run: |
           VERSION="${{ needs.release.outputs.version }}"
-          PKG_PATH=$(conan cache path "numops/${VERSION}:*" 2>/dev/null || true)
+          PKG_ID=$(conan list "numops/${VERSION}:*" --format=json \
+            | jq -r 'to_entries[0].value | to_entries[0].value.revisions
+                      | to_entries[0].value.packages | keys[0]')
+          PKG_PATH=$(conan cache path "numops/${VERSION}:${PKG_ID}")
           mkdir -p dist
-          if [ -n "${PKG_PATH}" ] && [ -d "${PKG_PATH}" ]; then
-            tar czf "dist/numops-${VERSION}-${{ matrix.os }}.tar.gz" -C "${PKG_PATH}" .
-          else
-            echo "Package path not found, creating metadata-only artifact"
-            echo "numops/${VERSION} published to conan-stable" > "dist/numops-${VERSION}-${{ matrix.os }}.txt"
-          fi
+          tar czf "dist/numops-${VERSION}-${{ matrix.os }}.tar.gz" -C "${PKG_PATH}" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(numops VERSION 1.0.0 LANGUAGES CXX)
+project(numops VERSION 1.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

- Fix release artifact packaging to produce proper `.tar.gz` archives
  containing headers and libraries instead of placeholder `.txt` files
- Use `conan list --format=json` + `jq` to resolve package ID, then
  `conan cache path` to locate the built package directory
- Bump version to 1.1.0

## Test plan

- [ ] All CI checks pass
- [ ] Merging with `publish` label creates v1.1.0 release with `.tar.gz` artifacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 1.1.0
  * Improved artifact packaging reliability in release workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->