### PR TITLE
fix: use checked-in Conan profiles instead of auto-detection in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            profile: conan/profiles/linux-x86_64
+          - os: macos-latest
+            profile: conan/profiles/macos-armv8
+          - os: windows-latest
+            profile: conan/profiles/windows-x86_64
 
     steps:
       - name: Checkout
@@ -23,6 +26,8 @@ jobs:
 
       - name: Set up Conan
         uses: skolobov/shared-workflows/actions/conan-setup@v1
+        with:
+          profile: ${{ matrix.profile }}
 
       - name: Configure
         run: cmake -B build -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Set up Conan
         uses: skolobov/shared-workflows/actions/conan-setup@v1
         with:
+          profile: conan/profiles/linux-x86_64
           cache-conan: "false"
 
       - name: Configure conan-stable remote
@@ -60,10 +61,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            profile: conan/profiles/linux-x86_64
+          - os: macos-latest
+            profile: conan/profiles/macos-armv8
+          - os: windows-latest
+            profile: conan/profiles/windows-x86_64
 
     steps:
       - name: Checkout
@@ -72,6 +76,7 @@ jobs:
       - name: Set up Conan
         uses: skolobov/shared-workflows/actions/conan-setup@v1
         with:
+          profile: ${{ matrix.profile }}
           cache-conan: "false"
 
       - name: Configure conan-rc remote

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,10 +50,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            profile: conan/profiles/linux-x86_64
+          - os: macos-latest
+            profile: conan/profiles/macos-armv8
+          - os: windows-latest
+            profile: conan/profiles/windows-x86_64
 
     steps:
       - name: Checkout
@@ -62,6 +65,7 @@ jobs:
       - name: Set up Conan
         uses: skolobov/shared-workflows/actions/conan-setup@v1
         with:
+          profile: ${{ matrix.profile }}
           cache-conan: "false"
 
       - name: Configure conan-stable remote

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,10 +14,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+            profile: conan/profiles/linux-x86_64
+          - os: macos-latest
+            profile: conan/profiles/macos-armv8
+          - os: windows-latest
+            profile: conan/profiles/windows-x86_64
 
     steps:
       - name: Checkout
@@ -25,6 +28,8 @@ jobs:
 
       - name: Set up Conan
         uses: skolobov/shared-workflows/actions/conan-setup@v1
+        with:
+          profile: ${{ matrix.profile }}
 
       - name: Compute RC version
         id: version

--- a/conan/profiles/linux-x86_64
+++ b/conan/profiles/linux-x86_64
@@ -3,5 +3,6 @@ os=Linux
 arch=x86_64
 compiler=gcc
 compiler.version=13
+compiler.cppstd=gnu17
 compiler.libcxx=libstdc++11
 build_type=Release

--- a/conan/profiles/macos-armv8
+++ b/conan/profiles/macos-armv8
@@ -2,6 +2,7 @@
 os=Macos
 arch=armv8
 compiler=apple-clang
-compiler.version=15
+compiler.version=17
+compiler.cppstd=gnu17
 compiler.libcxx=libc++
 build_type=Release

--- a/conan/profiles/macos-x86_64
+++ b/conan/profiles/macos-x86_64
@@ -1,7 +1,0 @@
-[settings]
-os=Macos
-arch=x86_64
-compiler=apple-clang
-compiler.version=15
-compiler.libcxx=libc++
-build_type=Release

--- a/conan/profiles/windows-x86_64
+++ b/conan/profiles/windows-x86_64
@@ -3,5 +3,7 @@ os=Windows
 arch=x86_64
 compiler=msvc
 compiler.version=194
+compiler.cppstd=14
 compiler.runtime=dynamic
+compiler.runtime_type=Release
 build_type=Release


### PR DESCRIPTION
## Summary

- Replace `conan profile detect` with explicit profile files in all workflows
- Update profiles to match current GitHub runner compilers (GCC 13, Apple Clang 17, MSVC 194)
- Add missing `compiler.cppstd` and `compiler.runtime_type` settings
- Remove unused `macos-x86_64` profile (runners are arm64)
- Update `conan-setup` shared action to accept a `profile` input
- Map CI matrix OS to specific profile files via `matrix.include`

## Test plan

- [ ] Build workflow passes with explicit profiles on all platforms
- [ ] Lint checks pass

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured CI/CD pipelines to explicitly specify Conan build profiles for each supported operating system and hardware architecture combination.
  * Enhanced compiler configurations for Linux, Windows, and macOS build environments with updated C++ language standards and compiler version specifications.
  * Phased out macOS x86_64 platform support; builds now exclusively target ARM-based macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->