### PR TITLE
feat: add divide function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21)
-project(numops VERSION 1.1.0 LANGUAGES CXX)
+project(numops VERSION 1.2.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/numops/numops.h
+++ b/include/numops/numops.h
@@ -12,6 +12,10 @@ int subtract(int a, int b);
 /// Returns the product of two integers.
 int multiply(int a, int b);
 
+/// Returns the result of integer division (a / b).
+/// If b is zero, returns 0.
+int divide(int a, int b);
+
 }  // namespace numops
 
 #endif  // NUMOPS_NUMOPS_H

--- a/src/numops.cpp
+++ b/src/numops.cpp
@@ -8,4 +8,6 @@ int subtract(int a, int b) { return a - b; }
 
 int multiply(int a, int b) { return a * b; }
 
+int divide(int a, int b) { return b == 0 ? 0 : a / b; }
+
 }  // namespace numops

--- a/test_package/src/example.cpp
+++ b/test_package/src/example.cpp
@@ -21,6 +21,11 @@ int main() {
         result = EXIT_FAILURE;
     }
 
+    if (numops::divide(10, 3) != 3) {
+        std::cerr << "FAIL: divide(10, 3) != 3\n";
+        result = EXIT_FAILURE;
+    }
+
     if (result == 0) {
         std::cout << "numops integration test: all checks passed\n";
     }

--- a/tests/integration/src/main.cpp
+++ b/tests/integration/src/main.cpp
@@ -21,6 +21,11 @@ int main() {
         result = EXIT_FAILURE;
     }
 
+    if (numops::divide(10, 3) != 3) {
+        std::cerr << "FAIL: divide(10, 3) != 3\n";
+        result = EXIT_FAILURE;
+    }
+
     if (result == EXIT_SUCCESS) {
         std::cout << "numops consumer test: all checks passed\n";
     }

--- a/tests/test_numops.cpp
+++ b/tests/test_numops.cpp
@@ -75,3 +75,33 @@ TEST(MultiplyTest, Identity) {
     EXPECT_EQ(numops::multiply(99, 1), 99);
     EXPECT_EQ(numops::multiply(-1, 42), -42);
 }
+
+// --- divide() tests ---
+
+TEST(DivideTest, ExactDivision) {
+    EXPECT_EQ(numops::divide(10, 2), 5);
+    EXPECT_EQ(numops::divide(100, 4), 25);
+}
+
+TEST(DivideTest, IntegerTruncation) {
+    EXPECT_EQ(numops::divide(7, 2), 3);
+    EXPECT_EQ(numops::divide(1, 3), 0);
+}
+
+TEST(DivideTest, NegativeNumbers) {
+    EXPECT_EQ(numops::divide(-10, 2), -5);
+    EXPECT_EQ(numops::divide(10, -2), -5);
+    EXPECT_EQ(numops::divide(-10, -2), 5);
+}
+
+TEST(DivideTest, DivideByZero) { EXPECT_EQ(numops::divide(42, 0), 0); }
+
+TEST(DivideTest, ZeroDividend) {
+    EXPECT_EQ(numops::divide(0, 5), 0);
+    EXPECT_EQ(numops::divide(0, -3), 0);
+}
+
+TEST(DivideTest, Identity) {
+    EXPECT_EQ(numops::divide(99, 1), 99);
+    EXPECT_EQ(numops::divide(-42, 1), -42);
+}


### PR DESCRIPTION
## Summary

- Add `numops::divide(a, b)` — integer division, returns 0 on division by zero
- Add 6 new unit tests (exact division, truncation, negatives, divide-by-zero, zero dividend, identity)
- Update `test_package` and integration test consumers to exercise `divide()`
- Bump version from 1.1.0 to 1.2.0

## Test plan

- [x] All 19 unit tests pass locally (macOS)
- [x] CI build matrix (Linux, macOS, Windows)
- [x] Can be released as v1.2.0 via `publish` label flow