### PR TITLE
fix(ci): align merge-gate check matching with workflow job names

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -37,7 +37,9 @@ jobs:
             echo "verify label found — checking integration tests..."
             VERIFY_STATUS=$(gh pr checks "${PR_NUMBER}" --repo "${REPO}" \
               --json name,state \
-              --jq "[.[] | select(.name | startswith(\"Integration\"))]
+              --jq "[.[] | select(
+                      .name
+                      | (startswith(\"Upload RC (\") or startswith(\"Consumer (\")))]
                     | ${JQ_STATUS}")
 
             echo "  Verify status: ${VERIFY_STATUS}"
@@ -55,7 +57,7 @@ jobs:
               --json name,state \
               --jq "[.[] | select(
                       .name | startswith(\"Publish RC\")
-                      or . == \"Check version\")]
+                      or .name == \"Check version\")]
                     | ${JQ_STATUS}")
 
             echo "  Publish status: ${PUBLISH_STATUS}"


### PR DESCRIPTION
## Summary
Align merge-gate check filtering with the actual Verify and Publish check names emitted by CI.

## Changes
- Update verify check selection logic in `.github/workflows/gate.yml`.
- Update publish check selection logic to correctly match the `Check version` check.

## Validation
- Workflow YAML lint passes locally.

Closes #40


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow check verification logic to enhance the accuracy of release validation and publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->