### PR TITLE
ci: enable clang-tidy with compile_commands.json

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Generate compile_commands.json
+        run: cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
       - name: C++ Linter
         uses: cpp-linter/cpp-linter-action@v2
         id: linter
@@ -41,7 +44,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           style: file
-          tidy-checks: "-*"
+          tidy-checks: ""
+          database: build
           version: 18
           files-changed-only: true
           thread-comments: true


### PR DESCRIPTION
## Summary

- Generate `compile_commands.json` via `cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- Pass compilation database to cpp-linter-action via `database` input
- Re-enable clang-tidy checks (use `.clang-tidy` config instead of `-*`)
- Clang-tidy can now properly resolve headers and run static analysis

## Test plan

- [ ] C++ Lint check passes with clang-tidy enabled
- [ ] No false positives from missing headers

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration pipeline with enhanced code analysis tooling and linting configuration for better automated code quality monitoring during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->