### PR TITLE
fix: use portable grep for version extraction across workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION=$(grep -oP 'project\(\s*numops\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+          VERSION=$(grep -oE 'project\(\s*numops\s+VERSION\s+[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
           RC_VERSION="${VERSION}-dev-${SHORT_SHA}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
@@ -35,7 +36,8 @@ jobs:
         run: |
           git fetch --no-tags origin "${{ github.base_ref }}" --depth=1
           BASE_VERSION=$(git show "origin/${{ github.base_ref }}:CMakeLists.txt" \
-            | grep -oP 'project\(\s*numops\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+')
+            | grep -oE 'project\(\s*numops\s+VERSION\s+[0-9]+\.[0-9]+\.[0-9]+' \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           HEAD_VERSION="${{ steps.version.outputs.version }}"
 
           echo "Base version: ${BASE_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          VERSION=$(grep -oP 'project\(\s*numops\s+VERSION\s+\K[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt)
+          VERSION=$(grep -oE 'project\(\s*numops\s+VERSION\s+[0-9]+\.[0-9]+\.[0-9]+' CMakeLists.txt \
+            | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Releasing version: ${VERSION}"
 


### PR DESCRIPTION
## Summary

- Replace `grep -oP` (Perl regex) with `grep -oE` (POSIX extended regex) in
  `publish.yml` and `release.yml`
- `verify.yml` already used the portable pattern — now all workflows are consistent
- `grep -oP` is not available on macOS, making the current code fragile

## Test plan

- [ ] CI passes on all platforms
- [ ] Version extraction still works correctly in publish and release workflows

Closes #52