### PR TITLE
refactor: use shared conan-build-upload workflow in verify and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,45 +80,13 @@ jobs:
           echo "Version ${VERSION} is available."
 
   publish-rc:
-    name: Publish RC (${{ matrix.os }})
+    name: Publish RC
     needs: check-version
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            profile: conan/profiles/linux-x86_64
-          - os: macos-latest
-            profile: conan/profiles/macos-armv8
-          - os: windows-latest
-            profile: conan/profiles/windows-x86_64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Conan
-        uses: skolobov/shared-workflows/actions/conan-setup@v1
-        with:
-          profile: ${{ matrix.profile }}
-          cache-conan: "false"
-
-      - name: Configure conan-rc remote
-        uses: skolobov/shared-workflows/actions/conan-remote@v1
-        with:
-          remote-name: conan-rc
-          remote-url: ${{ secrets.JFROG_URL }}
-          remote-user: ${{ secrets.JFROG_USER }}
-          remote-token: ${{ secrets.JFROG_TOKEN }}
-
-      - name: Build and upload RC package
-        shell: bash
-        run: |
-          conan lock create . --version="${{ needs.check-version.outputs.rc_version }}" \
-            --profile:host="${{ matrix.profile }}" \
-            --profile:build="${{ matrix.profile }}" \
-            --lockfile-out=conan.lock
-          conan create . --version="${{ needs.check-version.outputs.rc_version }}" \
-            --lockfile=conan.lock
-          conan upload "numops/${{ needs.check-version.outputs.rc_version }}" -r conan-rc --confirm
+    uses: skolobov/shared-workflows/.github/workflows/conan-build-upload.yml@v1
+    with:
+      version: ${{ needs.check-version.outputs.rc_version }}
+      remote-name: conan-rc
+    secrets:
+      remote-url: ${{ secrets.JFROG_URL }}
+      remote-user: ${{ secrets.JFROG_USER }}
+      remote-token: ${{ secrets.JFROG_TOKEN }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,48 +28,16 @@ jobs:
           echo "RC version: ${RC_VERSION}"
 
   upload-rc:
-    name: Upload RC (${{ matrix.os }})
+    name: Upload RC
     needs: compute-version
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            profile: conan/profiles/linux-x86_64
-          - os: macos-latest
-            profile: conan/profiles/macos-armv8
-          - os: windows-latest
-            profile: conan/profiles/windows-x86_64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Conan
-        uses: skolobov/shared-workflows/actions/conan-setup@v1
-        with:
-          profile: ${{ matrix.profile }}
-          cache-conan: "false"
-
-      - name: Configure conan-rc remote
-        uses: skolobov/shared-workflows/actions/conan-remote@v1
-        with:
-          remote-name: conan-rc
-          remote-url: ${{ secrets.JFROG_URL }}
-          remote-user: ${{ secrets.JFROG_USER }}
-          remote-token: ${{ secrets.JFROG_TOKEN }}
-
-      - name: Build and upload RC package
-        shell: bash
-        run: |
-          RC="${{ needs.compute-version.outputs.rc_version }}"
-          conan lock create . --version="${RC}" \
-            --profile:host="${{ matrix.profile }}" \
-            --profile:build="${{ matrix.profile }}" \
-            --lockfile-out=conan.lock
-          conan create . --version="${RC}" --lockfile=conan.lock
-          conan upload "numops/${RC}" -r conan-rc --confirm
+    uses: skolobov/shared-workflows/.github/workflows/conan-build-upload.yml@v1
+    with:
+      version: ${{ needs.compute-version.outputs.rc_version }}
+      remote-name: conan-rc
+    secrets:
+      remote-url: ${{ secrets.JFROG_URL }}
+      remote-user: ${{ secrets.JFROG_USER }}
+      remote-token: ${{ secrets.JFROG_TOKEN }}
 
   consumer-test:
     name: Consumer (${{ matrix.os }})


### PR DESCRIPTION
## Summary

- Replace duplicated build-upload matrix in `verify.yml` and `publish.yml` with
  calls to the reusable `conan-build-upload.yml` from shared-workflows
- `release.yml` kept as-is (has additional artifact packaging steps)

## Dependencies

**Merge order:**
1. First merge [shared-workflows PR #1](https://github.com/skolobov/shared-workflows/pull/1) and update the `v1` tag
2. Then merge this PR

## Test plan

- [ ] Verify workflow works with reusable workflow call
- [ ] Publish workflow works with reusable workflow call

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored CI/CD workflows to utilize a reusable workflow template for Conan build and upload operations, simplifying maintenance and reducing duplication across build pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->