### PR TITLE
fix(ci): add actions:write permission to gate re-trigger workflow

### DIFF
--- a/.github/workflows/gate-retrigger.yml
+++ b/.github/workflows/gate-retrigger.yml
@@ -8,6 +8,10 @@ on:
     types:
       - completed
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   retrigger:
     name: Re-trigger Merge Gate


### PR DESCRIPTION
## Summary

The gate re-trigger workflow failed with "Resource not accessible by integration"
because `workflow_run` tokens don't include `actions:write` by default.

Add explicit `permissions` block with `actions: write`.

## Test plan

- [ ] Merge this first, then test on PR #63 (abs function) by re-adding labels
- This fix must be on `main` before `workflow_run` can use it

Refs #60